### PR TITLE
Drop scoop as a dependency + rewrite Ahk2Exe script 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# GitHub-Action-Ahk2Exe

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,10 @@ inputs:
     description: The icon of the executable file is specified
     required: false
     default: ''
+  base:
+    description: The base file to be used for Ahk2Exe
+    required: false
+    default: 'Unicode 32-bit'
 
 runs:
   using: composite
@@ -26,11 +30,12 @@ runs:
         Expand-Archive -Path "$cwd\autohotkey.zip" -DestinationPath "$cwd\_autohotkey\" -Force;
         Remove-Item -Path "$cwd\autohotkey.zip" -Force
         Write-Output ("$cwd\_autohotkey\;" + "$cwd\_autohotkey\Compiler") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        Write-Output ("BaseFile=$cwd\_autohotkey\Compiler\${{inputs.base}}") | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
     - name: Run Ahk2Exe
       shell: pwsh
       run: |
-        $command = 'ahk2exe.exe /silent '
+        $command = 'ahk2exe.exe /silent verbose /base "$Env:BaseFile" '
         if('${{inputs.in}}' -ne ''){
           $command += '/in "${{inputs.in}}" '
         }

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
         Invoke-WebRequest "https://www.autohotkey.com/download/ahk.zip" -OutFile "$cwd\autohotkey.zip";
         Expand-Archive -Path "$cwd\autohotkey.zip" -DestinationPath "$cwd\_autohotkey\" -Force;
         Remove-Item -Path "$cwd\autohotkey.zip" -Force
-        $Env:GITHUB_ENV = Write-Output ("$cwd\_autohotkey\;" + "$cwd\_autohotkey\Compiler");
+        Write-Output ("$cwd\_autohotkey\;" + "$cwd\_autohotkey\Compiler") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Run Ahk2Exe
       shell: pwsh
@@ -40,7 +40,7 @@ runs:
         if('${{inputs.icon}}' -ne ''){
           $params += '/icon "${{inputs.icon}}" '
         }
-        .\_autohotkey\Compiler\ahk2exe.exe /silent $params | Write-Output
+        ahk2exe.exe /silent $params | Write-Output
         
 branding:
   color: green

--- a/action.yaml
+++ b/action.yaml
@@ -30,17 +30,18 @@ runs:
     - name: Run Ahk2Exe
       shell: pwsh
       run: |
-        $params = ''
+        $command = 'ahk2exe.exe /silent '
         if('${{inputs.in}}' -ne ''){
-          $params += '/in "${{inputs.in}}" '
+          $command += '/in "${{inputs.in}}" '
         }
         if('${{inputs.out}}' -ne ''){
-          $params += '/out "${{inputs.out}}" '
+          $command += '/out "${{inputs.out}}" '
         }
         if('${{inputs.icon}}' -ne ''){
-          $params += '/icon "${{inputs.icon}}" '
+          $command += '/icon "${{inputs.icon}}" '
         }
-        ahk2exe.exe /silent $params | Write-Output
+        $command += "| Write-Output"
+        Invoke-Expression $command
         
 branding:
   color: green

--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Install AutoHotkey
-      shell: powershell
+      shell: pwsh
       run: |
         $cwd = (Get-Item .).FullName;
         Invoke-WebRequest "https://www.autohotkey.com/download/ahk.zip" -OutFile "$cwd\autohotkey.zip";
@@ -28,7 +28,7 @@ runs:
         $Env:GITHUB_ENV = Write-Output ("$cwd\_autohotkey\;" + "$cwd\_autohotkey\Compiler");
 
     - name: Run Ahk2Exe
-      shell: powershell
+      shell: pwsh
       run: |
         $params = ''
         if('${{inputs.in}}' -ne ''){
@@ -40,7 +40,7 @@ runs:
         if('${{inputs.icon}}' -ne ''){
           $params += '/icon "${{inputs.icon}}" '
         }
-        ahk2exe.exe /silent $params | Write-Output
+        .\_autohotkey\Compiler\ahk2exe.exe /silent $params | Write-Output
         
 branding:
   color: green

--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ''
   base:
-    description: The base file to be used for Ahk2Exe
+    description: The name of the base file to be used for Ahk2Exe
     required: false
     default: 'Unicode 32-bit'
 
@@ -30,7 +30,7 @@ runs:
         Expand-Archive -Path "$cwd\autohotkey.zip" -DestinationPath "$cwd\_autohotkey\" -Force;
         Remove-Item -Path "$cwd\autohotkey.zip" -Force
         Write-Output ("$cwd\_autohotkey\;" + "$cwd\_autohotkey\Compiler") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        Write-Output ("BaseFile=$cwd\_autohotkey\Compiler\${{inputs.base}}") | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        Write-Output ("BaseFile=$cwd\_autohotkey\Compiler\${{inputs.base}}.bin") | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
     - name: Run Ahk2Exe
       shell: pwsh

--- a/action.yaml
+++ b/action.yaml
@@ -31,12 +31,15 @@ runs:
       shell: powershell
       run: |
         $params = ''
-        if('${{inputs.in}}' -ne '')
+        if('${{inputs.in}}' -ne ''){
           $params += '/in "${{inputs.in}}" '
-        if('${{inputs.out}}' -ne '')
+        }
+        if('${{inputs.out}}' -ne ''){
           $params += '/out "${{inputs.out}}" '
-        if('${{inputs.icon}}' -ne '')
+        }
+        if('${{inputs.icon}}' -ne ''){
           $params += '/icon "${{inputs.icon}}" '
+        }
         ahk2exe.exe /silent $params | Write-Output
         
 branding:

--- a/action.yaml
+++ b/action.yaml
@@ -17,7 +17,7 @@ inputs:
   base:
     description: The name of the base file to be used for Ahk2Exe
     required: false
-    default: 'Unicode 32-bit'
+    default: ''
 
 runs:
   using: composite
@@ -30,12 +30,16 @@ runs:
         Expand-Archive -Path "$cwd\autohotkey.zip" -DestinationPath "$cwd\_autohotkey\" -Force;
         Remove-Item -Path "$cwd\autohotkey.zip" -Force
         Write-Output ("$cwd\_autohotkey\;" + "$cwd\_autohotkey\Compiler") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        Write-Output ("BaseFile=$cwd\_autohotkey\Compiler\${{inputs.base}}.bin") | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        if('${{inputs.base}}' -ne ''){
+          Write-Output ("BaseFile=$cwd\_autohotkey\Compiler\${{inputs.base}}.bin") | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        }else{
+          Copy-Item -Path "$cwd\_autohotkey\Compiler\Unicode 32-bit.bin" -Destination "$cwd\_autohotkey\Compiler\AutoHotkeySC.bin"
+        }
 
     - name: Run Ahk2Exe
       shell: pwsh
       run: |
-        $command = 'ahk2exe.exe /silent verbose /base "$Env:BaseFile" '
+        $command = 'ahk2exe.exe /silent verbose '
         if('${{inputs.in}}' -ne ''){
           $command += '/in "${{inputs.in}}" '
         }
@@ -44,6 +48,9 @@ runs:
         }
         if('${{inputs.icon}}' -ne ''){
           $command += '/icon "${{inputs.icon}}" '
+        }
+        if('${{inputs.base}}' -ne ''){
+          $command += '/base "$Env:BaseFile" '
         }
         $command += "| Write-Output"
         Invoke-Expression $command

--- a/action.yaml
+++ b/action.yaml
@@ -18,35 +18,27 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Scoop
-      shell: powershell
-      run: |
-        iwr -useb get.scoop.sh | iex
-        scoop bucket add extras
-
-    - name: Add to environment variables
-      shell: powershell
-      run: Write-Output ('Path=' + $Env:SystemDrive + '\Windows\System32' + ';' + $Env:UserProfile + '\scoop\shims') >> $Env:GITHUB_ENV
-
     - name: Install AutoHotkey
       shell: powershell
-      run: scoop install autohotkey
+      run: |
+        $cwd = (Get-Item .).FullName;
+        Invoke-WebRequest "https://www.autohotkey.com/download/ahk.zip" -OutFile "$cwd\autohotkey.zip";
+        Expand-Archive -Path "$cwd\autohotkey.zip" -DestinationPath "$cwd\_autohotkey\" -Force;
+        Remove-Item -Path "$cwd\autohotkey.zip" -Force
+        $Env:GITHUB_ENV = Write-Output ("$cwd\_autohotkey\;" + "$cwd\_autohotkey\Compiler");
 
-    - name: Ahk2Exe
+    - name: Run Ahk2Exe
       shell: powershell
       run: |
-        if (('${{inputs.in}}' -ne '') -and ('${{inputs.out}}' -ne '') -and ('${{inputs.icon}}' -ne '')) {
-          ahk2exe /in '${{inputs.in}}' /out '${{inputs.out}}' /icon '${{inputs.icon}}'
-        } elseif (('${{inputs.in}}' -ne '') -and ('${{inputs.out}}' -ne '')) {
-          ahk2exe /in '${{inputs.in}}' /out '${{inputs.out}}'
-        } elseif (('${{inputs.in}}' -ne '') -and ('${{inputs.icon}}' -ne '')) {
-          ahk2exe /in '${{inputs.in}}' /icon '${{inputs.icon}}'
-        } elseif ('${{inputs.in}}' -ne '') {
-          ahk2exe /in '${{inputs.in}}'
-        } else {
-          throw 'There are no required parameters'
-        }
-
+        $params = ''
+        if('${{inputs.in}}' -ne '')
+          $params += '/in "${{inputs.in}}" '
+        if('${{inputs.out}}' -ne '')
+          $params += '/out "${{inputs.out}}" '
+        if('${{inputs.icon}}' -ne '')
+          $params += '/icon "${{inputs.icon}}" '
+        ahk2exe.exe /silent $params | Write-Output
+        
 branding:
   color: green
   icon: terminal


### PR DESCRIPTION
I replaced scoop because it takes a lot of time to install its own dependencies like git and 7z and then git clones a bunch of repos (scoop main, scoop extras) which is unnecessary imo, especially since autohotkey is already offered as a [portable zip file](https://www.autohotkey.com/download/ahk.zip).

My script will download the zip file, extract it and add the compiler directory to the environment path

I also rewrote the `Ahk2Exe` script to make it simpler (to potentially add extra parameters in the future)